### PR TITLE
Feature input permutations

### DIFF
--- a/code/data_preparer.py
+++ b/code/data_preparer.py
@@ -42,8 +42,9 @@ class PixelListPreparer:
                        self.neighbour_pixels:-self.neighbour_pixels, :] = img
             self.add_to_dataset(padded_img, labels)
 
-    def add_to_dataset(self, image, labels):
-        """Loops through a single image and creates a matched dataset of image chunks and labels. 
+    def add_to_dataset(self, image, labels, bands=[0, 1, 2, 3, 4, 5]):
+        """Loops through a single image and creates a matched dataset of image segments and labels
+        from a particular set of bands.
 
         Args:
             image (np.array(dtype='unit8')): Numpy array resulting from the conversion of a GeoTIFF
@@ -52,8 +53,11 @@ class PixelListPreparer:
             labels (np.array(dtype='unit8')): Binary array of the same dimensions as the input image
                 where 1 represents a smoke pixel and 0 represents non-smoke pixel
 
+            bands (list): List containing integer band labels. This will be used to determine which
+                bands are added to self.dataset. Default: [0, 1, 2, 3, 4, 5] (all six bands)
+
         Returns:
-            No direct return, but modifies self.dataset and self.labels. self.dataset will be 
+            No direct return, but modifies self.dataset and self.labels. self.dataset will be
             a list of neighbour_pixels*2 x neighbour_pixels*2 np.arrays with a corresponding self.
             labels that contains the label for smoke or nonsmoke
         """
@@ -64,7 +68,7 @@ class PixelListPreparer:
             for column in range(0, width):
                 self.dataset.append(
                     image[row:(row + number_of_pixels),
-                          column:(column + number_of_pixels), :])
+                          column:(column + number_of_pixels), bands)
                 label = 1 if labels[row, column] == 255 else 0
                 self.labels.append(label)
 


### PR DESCRIPTION
**Motivation**
Currently, a configuration file determines the number of bands pulled from the NetCDF during preprocessing, and this data is fed into the model which excepts only a specific band number. This process would require multiple different preprocessed combinations to be created, which presents a storage and time issue. In order to address this, we will change the preprocessing pipeline so that only GeoTIFFs with 6 bands will be created, and process which converts GeoTIFFs to model input will work off the config.py to select the appropriate bands. 

**Changes**
Updates data_preparer.py PixelListPreparer.add_to_dataset() to include an input parameter for bands. This parameter allows the user to select which bands will be added to PixelListPreparer.dataset.
Updated docstring to include information about the function, parameters, and return.

**Merge Ramifications**
None. Although data_preparer.py PixelListPreparer.add_to_dataset() gained a new parameter, this was given a default value that will preserve old functionality when merged to master. 

**Trello**
[(3) Structure the process so that the pre-processing is not repeated](https://trello.com/c/DLF3mhQB/441-3-structure-the-process-so-that-the-pre-processing-is-not-repeated)